### PR TITLE
Fix ambiguity of the environment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To get started, a sample docker-compose file is located in the resources/docs fo
 - `EDC_API_AUTH_KEY:` _The API authorization key of management API_
       
 #### MDS Environment Configuration
-The test environment is set by default.
+The dev environment is set by default.
 - `EDC_BROKER_BASE_URL:` https://broker.dev.mobility-dataspace.eu
 - `EDC_OAUTH_CLIENT_ID:` _To be able to start an EDC-Connector with the broker-extensions, the `SKI` and `AKI` of the connector certificate must be entered as `client-ID` in the docker-compose and the .jks must be placed under the path specified in the docker-compose (in the example in the folder `resources/vault/edc/`, see `EDC_KEYSTORE` setting)._
 - `EDC_OAUTH_TOKEN_URL:` https://daps.dev.mobility-dataspace.eu/token

--- a/resources/docs/docker-compose.yml
+++ b/resources/docs/docker-compose.yml
@@ -18,14 +18,14 @@ services:
       UPDATE_INTERVAL_IN_SECONDS: 5
       EDC_WEB_REST_CORS_ENABLED: "true"
       EDC_WEB_REST_CORS_HEADERS: "origin,content-type,accept,authorization,x-api-key"
-      EDC_BROKER_BASE_URL: https://broker.test.mobility-dataspace.eu
+      EDC_BROKER_BASE_URL: https://broker.dev.mobility-dataspace.eu
       EDC_KEYSTORE: /resources/vault/edc/keystore.jks
       EDC_KEYSTORE_PASSWORD: password
       EDC_OAUTH_PUBLIC_KEY_ALIAS: 1
       EDC_OAUTH_PRIVATE_KEY_ALIAS: 1
       EDC_OAUTH_CLIENT_ID:
-      EDC_OAUTH_TOKEN_URL: https://daps.test.mobility-dataspace.eu/token
-      EDC_OAUTH_PROVIDER_JWKS_URL: https://daps.test.mobility-dataspace.eu/jwks.json
+      EDC_OAUTH_TOKEN_URL: https://daps.dev.mobility-dataspace.eu/token
+      EDC_OAUTH_PROVIDER_JWKS_URL: https://daps.dev.mobility-dataspace.eu/jwks.json
       EDC_OAUTH_PROVIDER_AUDIENCE: idsc:IDS_CONNECTORS_ALL
     ports:
       - "9191:9191"


### PR DESCRIPTION
# Pull Request
Make the dev environment the default by updating the documentation and urls in docker-compose.

## How Has This Been Tested?
Do the dev urls even work? @efiege 

## Linked Issue(s)
- closes https://github.com/sovity/edc-extensions/issues/8


# Checklist
- [x] I have **formatted the title** correctly and precisely
- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my own code
- [x] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
- [x] I have made corresponding changes to the **documentation**
- [x] My changes generate **no new warnings** (performed checkstyle check locally)
- [x] I have added **tests that prove my fix** is effective or that my feature works
- [x] New and existing unit **tests pass locally** with my changes
- [x] Any dependent **changes have been merged** and published in downstream modules
- [x] I have added/updated **copyright headers**
