### PR TITLE
fix: connector not registering to broker due to null pointer exception

### DIFF
--- a/extensions/catalog-transfer-extension/src/main/java/sender/RegisterConnectorRequestSender.java
+++ b/extensions/catalog-transfer-extension/src/main/java/sender/RegisterConnectorRequestSender.java
@@ -48,6 +48,7 @@ public class RegisterConnectorRequestSender implements MultipartSenderDelegate<R
                                           String endpoint) {
         this.objectMapper = objectMapper;
         this.connectorName = connectorName;
+        this.endpoint = endpoint;
     }
 
     @Override


### PR DESCRIPTION
# Pull Request
Previously the connector wasnt being registered due to a null pointer exception. This fix adds the missing field that caused the exception.  Since the connector is now being registered to the broker this fixes the problem that title, maintainer and curator weren't being updated. 

## How Has This Been Tested?
I tested this with a custom run configuration.


## Linked Issue(s)
- fixes https://github.com/sovity/edc-extensions/issues/9

# Checklist
- [x] I have **formatted the title** correctly and precisely
- [x] My code follows the **style guidelines** of this project
- [x] I have performed a **self-review** of my own code
- [x] I have **commented** my code, particularly in hard-to-understand areas and public classes/methods
- [x] I have made corresponding changes to the **documentation**
- [x] My changes generate **no new warnings** (performed checkstyle check locally)
- [x] I have added **tests that prove my fix** is effective or that my feature works
- [x] New and existing unit **tests pass locally** with my changes
- [x] Any dependent **changes have been merged** and published in downstream modules
- [x] I have added/updated **copyright headers**
