### PR TITLE
feat: unregister connector on shutdown

### DIFF
--- a/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
@@ -251,6 +251,11 @@ public class BrokerExtension implements ServiceExtension {
     }
 
     @Override
+    public void shutdown(){
+        idsBrokerService.unregisterConnectorAtBroker(brokerBaseUrl);
+    }
+
+    @Override
     public void prepare() {
         ServiceExtension.super.prepare();
     }

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
@@ -251,7 +251,7 @@ public class BrokerExtension implements ServiceExtension {
     }
 
     @Override
-    public void shutdown(){
+    public void shutdown() {
         idsBrokerService.unregisterConnectorAtBroker(brokerBaseUrl);
     }
 

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/BrokerExtension.java
@@ -26,6 +26,7 @@ import de.fraunhofer.iais.eis.ResourceUpdateMessage;
 import de.sovity.extension.broker.sender.QueryMessageRequestSender;
 import de.sovity.extension.broker.sender.RegisterConnectorRequestSender;
 import de.sovity.extension.broker.sender.RegisterResourceRequestSender;
+import de.sovity.extension.broker.sender.UnregisterConnectorRequestSender;
 import de.sovity.extension.broker.sender.UnregisterResourceRequestSender;
 import de.sovity.extension.broker.sender.message.brokerdispatcher.IdsMultipartExtendedRemoteMessageDispatcher;
 import de.sovity.extension.broker.serializer.MultiContextJsonLdSerializer;
@@ -226,6 +227,7 @@ public class BrokerExtension implements ServiceExtension {
 
         var registerConnectorSender = new RegisterConnectorRequestSender(objectMapper, connectorName, endpoint, description);
         var registerResourceSender = new RegisterResourceRequestSender(objectMapper);
+        var unregisterConnectorSender = new UnregisterConnectorRequestSender();
         var unregisterResourceSender = new UnregisterResourceRequestSender();
         var queryMessageRequestSender = new QueryMessageRequestSender();
 
@@ -235,6 +237,7 @@ public class BrokerExtension implements ServiceExtension {
         dispatcher.register(registerResourceSender);
         dispatcher.register(unregisterResourceSender);
         dispatcher.register(queryMessageRequestSender);
+        dispatcher.register(unregisterConnectorSender);
         dispatcherRegistry.register(dispatcher);
     }
 

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/sender/UnregisterConnectorRequestSender.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/sender/UnregisterConnectorRequestSender.java
@@ -13,7 +13,10 @@
  */
 package de.sovity.extension.broker.sender;
 
-import de.fraunhofer.iais.eis.*;
+import de.fraunhofer.iais.eis.ConnectorUnavailableMessageBuilder;
+import de.fraunhofer.iais.eis.DynamicAttributeToken;
+import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.MessageProcessedNotificationMessageImpl;
 import de.sovity.extension.broker.sender.message.UnregisterConnectorMessage;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
 import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/sender/UnregisterConnectorRequestSender.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/sender/UnregisterConnectorRequestSender.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2022 sovity GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       sovity GmbH - initial API and implementation
+ *
+ */
+package de.sovity.extension.broker.sender;
+
+import de.fraunhofer.iais.eis.*;
+import de.sovity.extension.broker.sender.message.UnregisterConnectorMessage;
+import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.MultipartSenderDelegate;
+import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.IdsMultipartParts;
+import org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.response.MultipartResponse;
+import org.eclipse.edc.protocol.ids.spi.domain.IdsConstants;
+import org.eclipse.edc.protocol.ids.util.CalendarUtil;
+
+import java.util.List;
+
+import static org.eclipse.edc.protocol.ids.api.multipart.dispatcher.sender.util.ResponseUtil.parseMultipartStringResponse;
+import static org.eclipse.edc.protocol.ids.jsonld.JsonLd.getObjectMapper;
+
+public class UnregisterConnectorRequestSender implements MultipartSenderDelegate<UnregisterConnectorMessage, String> {
+
+    @Override
+    public Message buildMessageHeader(UnregisterConnectorMessage unregisterConnectorMessage,
+                                      DynamicAttributeToken token) throws Exception {
+        return new ConnectorUnavailableMessageBuilder()
+                ._modelVersion_(IdsConstants.INFORMATION_MODEL_VERSION)
+                ._issued_(CalendarUtil.gregorianNow())
+                ._securityToken_(token)
+                ._issuerConnector_(unregisterConnectorMessage.connectorBaseUrl())
+                ._senderAgent_(unregisterConnectorMessage.connectorBaseUrl())
+                ._affectedConnector_(unregisterConnectorMessage.connectorBaseUrl())
+                .build();
+    }
+
+    @Override
+    public String buildMessagePayload(UnregisterConnectorMessage request) throws Exception {
+        return null;
+    }
+
+    @Override
+    public MultipartResponse<String> getResponseContent(IdsMultipartParts parts) throws Exception {
+        return parseMultipartStringResponse(parts, getObjectMapper());
+    }
+
+    @Override
+    public List<Class<? extends Message>> getAllowedResponseTypes() {
+        return List.of(MessageProcessedNotificationMessageImpl.class);
+    }
+
+    @Override
+    public Class<UnregisterConnectorMessage> getMessageType() {
+        return UnregisterConnectorMessage.class;
+    }
+}

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/sender/message/UnregisterConnectorMessage.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/sender/message/UnregisterConnectorMessage.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022 sovity GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       sovity GmbH - initial API and implementation
+ *
+ */
+package de.sovity.extension.broker.sender.message;
+
+import de.sovity.extension.broker.sender.message.brokerdispatcher.ExtendedMessageProtocol;
+import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+
+import java.net.URI;
+import java.net.URL;
+
+public record UnregisterConnectorMessage(URL brokerUrl,
+                                        // Broker seems only to accept connector ID's starting
+                                        // with http or https
+                                        URI connectorBaseUrl) implements RemoteMessage {
+
+    @Override
+    public String getProtocol() {
+        return ExtendedMessageProtocol.IDS_EXTENDED_PROTOCOL;
+    }
+
+    @Override
+    public String getConnectorAddress() {
+        return brokerUrl.toString();
+    }
+}

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/service/IdsBrokerServiceImpl.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/service/IdsBrokerServiceImpl.java
@@ -16,6 +16,7 @@ package de.sovity.extension.broker.service;
 import de.sovity.extension.broker.sender.message.QueryMessage;
 import de.sovity.extension.broker.sender.message.RegisterConnectorMessage;
 import de.sovity.extension.broker.sender.message.RegisterResourceMessage;
+import de.sovity.extension.broker.sender.message.UnregisterConnectorMessage;
 import de.sovity.extension.broker.sender.message.UnregisterResourceMessage;
 import org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
@@ -89,6 +90,7 @@ public class IdsBrokerServiceImpl implements IdsBrokerService, EventSubscriber {
                     connectorServiceSettings.getMaintainer());
             dispatcherRegistry.send(Object.class, registerConnectorMessage,
                     () -> CONTEXT_BROKER_REGISTRATION);
+            monitor.info("Registering Connector at Broker.");
         } catch (MalformedURLException e) {
             throw new EdcException("Could not build brokerInfrastructureUrl", e);
         } catch (URISyntaxException e) {
@@ -99,7 +101,19 @@ public class IdsBrokerServiceImpl implements IdsBrokerService, EventSubscriber {
 
     @Override
     public void unregisterConnectorAtBroker(URL brokerBaseUrl) {
-
+        try {
+            var brokerInfrastructureUrl = new URL(String.format("%s/infrastructure",
+                    brokerBaseUrl));
+            var connectorBaseUrl = new URI(String.format("http://%s/", hostname.get()));
+            var unregisterConnectorMessage = new UnregisterConnectorMessage(brokerInfrastructureUrl, connectorBaseUrl);
+            dispatcherRegistry.send(Object.class, unregisterConnectorMessage, () -> CONTEXT_BROKER_REGISTRATION);
+            monitor.info("Unregistering Connector at Broker.");
+        } catch (MalformedURLException e) {
+            throw new EdcException("Could not build brokerInfrastructureUrl", e);
+        } catch (URISyntaxException e) {
+            throw new EdcException("Could not create connectorBaseUrl. Hostname can be set using:" +
+                    " edc.hostname", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Pull Request
This PR implements necessary classes and methods to unregister a connector at the broker. 
Conveniently enough, unregistering the connector also unregisters the resources. 

## How Has This Been Tested?
I tested this with the test broker and run configuration. On graceful shutdown (exit in intellij, not stop) the connector gets unregistered and the resources also disappear from the broker.

## Linked Issue(s)
- closes https://github.com/sovity/edc-extensions/issues/41
