### PR TITLE
chore: add support for newer openssl versions to get_client script

### DIFF
--- a/resources/docs/get_client.sh
+++ b/resources/docs/get_client.sh
@@ -19,7 +19,12 @@ CRT_FILE="./cert.crt"
 
 if [ -n "$P12_FILE" ]; then
     [ ! -f "$P12_FILE" ] && (echo "Cert not found"; exit 1)
-    openssl pkcs12 -in "$P12_FILE" -clcerts -nokeys -out "$CRT_FILE" -passin "pass:$PASSWORD"
+    if [[ $(openssl version) == *"1.1.1"* ]];
+    then
+        openssl pkcs12 -in "$P12_FILE" -clcerts -nokeys -out "$CRT_FILE" -passin "pass:$PASSWORD"
+    else
+        openssl pkcs12 -in "$P12_FILE" -clcerts -nokeys -legacy -out "$CRT_FILE" -passin "pass:$PASSWORD"
+    fi
     openssl x509 -in "$CRT_FILE" -text > "$TEMP_FILE"
     keytool -importkeystore -srckeystore "$P12_FILE" -srcstoretype pkcs12 -destkeystore "$JKS_FILE" -deststoretype jks -deststorepass "$PASSWORD" -srcstorepass "$PASSWORD" -noprompt 2>/dev/null
 fi


### PR DESCRIPTION
# Pull Request

Adds support for newer openssl versions

## How Has This Been Tested?
Tested locally with version 1.1.1. Couldnt test with newer version.
## Linked Issue(s)
-   closes https://github.com/sovity/edc-extensions/issues/62

