### PR TITLE
fix: update ports of postman_collection.json

### DIFF
--- a/resources/docs/postman_collection.json
+++ b/resources/docs/postman_collection.json
@@ -227,7 +227,7 @@
 	"variable": [
 		{
 			"key": "data_management_url",
-			"value": "http://localhost:9191/api/v1/data",
+			"value": "http://localhost:11002/api/v1/data",
 			"type": "default"
 		},
 		{


### PR DESCRIPTION
The Postman Collection ports were outdated due to changes in the docker-compose.
Closes #88 