### PR TITLE
fix: last-commit-info-Extension tests are failing

### DIFF
--- a/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoEnvTest.java
+++ b/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoEnvTest.java
@@ -17,13 +17,11 @@ package de.sovity.edc.extension.version.controller;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static de.sovity.edc.extension.version.controller.TestUtils.createConfiguration;
 import static de.sovity.edc.extension.version.controller.TestUtils.mockRequest;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
 @ApiTest

--- a/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoEnvTest.java
+++ b/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoEnvTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static de.sovity.edc.extension.version.controller.TestUtils.createConfiguration;
 import static de.sovity.edc.extension.version.controller.TestUtils.mockRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 
 @ApiTest
 @ExtendWith(EdcExtension.class)
@@ -34,11 +35,10 @@ class LastCommitInfoEnvTest {
         extension.setConfiguration(createConfiguration("env"));
     }
 
-    @Disabled("As it fails. See #132")
     @Test
     void testEnvAndJar() {
         var request = mockRequest();
-        request.assertThat().body(containsString("pipeline"));
-        request.assertThat().body(containsString("env"));
+        request.assertThat().body(containsStringIgnoringCase("pipeline"));
+        request.assertThat().body(containsStringIgnoringCase("env"));
     }
 }

--- a/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoJarTest.java
+++ b/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoJarTest.java
@@ -17,13 +17,11 @@ package de.sovity.edc.extension.version.controller;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static de.sovity.edc.extension.version.controller.TestUtils.createConfiguration;
 import static de.sovity.edc.extension.version.controller.TestUtils.mockRequest;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.not;
 

--- a/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoJarTest.java
+++ b/extensions/last-commit-info/src/test/java/de/sovity/edc/extension/version/controller/LastCommitInfoJarTest.java
@@ -18,11 +18,13 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.junit.extensions.EdcExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static de.sovity.edc.extension.version.controller.TestUtils.createConfiguration;
 import static de.sovity.edc.extension.version.controller.TestUtils.mockRequest;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.not;
 
 @ApiTest
@@ -34,11 +36,10 @@ class LastCommitInfoJarTest {
         extension.setConfiguration(createConfiguration(""));
     }
 
-
-    @Disabled("As it fails. See #132")
+    @Test
     void testOnlyJar() {
         var request = mockRequest();
-        request.assertThat().body(containsString("pipeline"));
-        request.assertThat().body(not(containsString("env")));
+        request.assertThat().body(containsStringIgnoringCase("pipeline"));
+        request.assertThat().body(not(containsStringIgnoringCase("env")));
     }
 }


### PR DESCRIPTION
Fixes last-commit-info-Extension tests are failing.
Closes #132