### PR TITLE
add README.md to last commit info extension

### DIFF
--- a/extensions/last-commit-info/README.md
+++ b/extensions/last-commit-info/README.md
@@ -1,0 +1,47 @@
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/sovity/edc-ui">
+    <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
+  </a>
+
+<h3 align="center">EDC-Connector Extension:<br />Last Commit Info</h3>
+
+  <p align="center">
+    <a href="https://github.com/sovity/edc-extensions/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/sovity/edc-extensions/issues">Request Feature</a>
+  </p>
+</div>
+
+## About this Extension
+It adds an API endpoint `/last-commit-info` which returns the commit information of 
+the last commits of built EDC Connector and the edc-extensions JAR.
+
+## Why does this extension exist?
+
+Building EDC Connectors always requires you to build your own EDC Connector and EDC Connector Image.
+
+We needed a way to find out the versions of running EDC Connector instances.
+
+We found that finding the last commit of the EDC Connector Image was the most accurate way we could judge the 
+running EDC Connector instance.
+
+Since our EDC Images often use our EDC Extensions from this repository we also embed a second "jar last commit info"
+during build time of the edc-extensions, which can then represent all other EDC Extensions of this repository, since
+they will always be used with the same version.
+
+## Configuration
+
+### Connector Version
+The ENV Var `EDC_LAST_COMMIT_INFO` should be set in the Dockerfile via build args.
+
+### JAR Version
+The contents of the file `src/main/resources/jar-last-commit-info.txt` will be by the 
+edc-extensions GitHub pipeline to reflect the last commit info.
+
+## License
+Apache License 2.0 - see [LICENSE](../../LICENSE)
+
+## Contact
+Sovity GmbH - contact@sovity.de 

--- a/extensions/policy-always-true/README.md
+++ b/extensions/policy-always-true/README.md
@@ -1,15 +1,34 @@
-# Extension: policy-always-true
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  <a href="https://github.com/sovity/edc-ui">
+    <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
+  </a>
 
-Creates Policy Definition `Always True` / `always-true`.
+<h3 align="center">EDC-Connector Extension:<br />Last Commit Info</h3>
 
-Also adds `always-true` policy to get this done.
+  <p align="center">
+    <a href="https://github.com/sovity/edc-extensions/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/sovity/edc-extensions/issues">Request Feature</a>
+  </p>
+</div>
+
+## About this Extension
+This extension creates a Policy Definition `always-true` on EDC startup.
 
 ## Why does this extension exist?
 
-When creating a contract definition one must specify both an access policy and a contract policy.
+While the default behavior for contract definitions with empty policies is not "default deny", 
+our UI will be ensuring non-empty access and contract policies.
 
-While testing EDC data transfers, access policies and contract policies matter less important, however, one is forced to
-create one to use one.
+Therefore, it is of interest to have an `always-true` policy to explicitly enable full access in contract definitions.
 
-Instead of being forced to create policy definitions, the default policy definition created by this extension with
-ID `always-true` adds a usable policy definition out-of-the-box, so one can use policies where they actually matter.
+Since much of EDC production use is still testing of MVPs the ability to "just create a contract definition" is
+much welcomed.
+
+## License
+Apache License 2.0 - see [LICENSE](../../LICENSE)
+
+## Contact
+Sovity GmbH - contact@sovity.de


### PR DESCRIPTION
The README.md changes in full view are:
https://github.com/sovity/edc-extensions/tree/2023-03-02-fix-last-commit-info-readme/extensions/last-commit-info
https://github.com/sovity/edc-extensions/tree/2023-03-02-fix-last-commit-info-readme/extensions/policy-always-true