### PR TITLE
feat: Add possibility to flyway repair when migrations failed

### DIFF
--- a/extensions/postgres-flyway/src/main/java/de/sovity/edc/extension/postgresql/PostgresFlywayExtension.java
+++ b/extensions/postgres-flyway/src/main/java/de/sovity/edc/extension/postgresql/PostgresFlywayExtension.java
@@ -16,10 +16,15 @@ package de.sovity.edc.extension.postgresql;
 
 import de.sovity.edc.extension.postgresql.migration.DatabaseMigrationManager;
 import de.sovity.edc.extension.postgresql.migration.FlywayService;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 public class PostgresFlywayExtension implements ServiceExtension {
+
+
+    @Setting
+    public static final String EDC_DATASOURCE_REPAIR_SETTING = "edc.flyway.repair";
 
     @Override
     public String name() {
@@ -28,7 +33,8 @@ public class PostgresFlywayExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var flywayService = new FlywayService(context.getMonitor());
+        var tryRepairOnFailedMigration = context.getSetting(EDC_DATASOURCE_REPAIR_SETTING, false);
+        var flywayService = new FlywayService(context.getMonitor(), tryRepairOnFailedMigration);
         var migrationManager = new DatabaseMigrationManager(context.getConfig(), flywayService);
         migrationManager.migrateAllDataSources();
     }

--- a/extensions/postgres-flyway/src/main/java/de/sovity/edc/extension/postgresql/migration/FlywayService.java
+++ b/extensions/postgres-flyway/src/main/java/de/sovity/edc/extension/postgresql/migration/FlywayService.java
@@ -20,8 +20,10 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.sql.datasource.ConnectionFactoryDataSource;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.output.MigrateResult;
+import org.flywaydb.core.api.output.RepairResult;
 
 import javax.sql.DataSource;
 
@@ -30,27 +32,72 @@ public class FlywayService {
     private static final String MIGRATION_LOCATION_BASE = "classpath:migration";
 
     private final Monitor monitor;
+    private final boolean tryRepairOnFailedMigration;
 
-    public FlywayService(Monitor monitor) {
+    public FlywayService(Monitor monitor, boolean tryRepairOnFailedMigration) {
         this.monitor = monitor;
+        this.tryRepairOnFailedMigration = tryRepairOnFailedMigration;
     }
 
     public void migrateDatabase(
             String datasourceName,
             JdbcConnectionProperties jdbcConnectionProperties) {
+        var flyway = setupFlyway(datasourceName, jdbcConnectionProperties);
+        try {
+            var migrateResult = flyway.migrate();
+            handleFlywayMigrationResult(datasourceName, migrateResult);
+        } catch (FlywayException e) {
+            if (tryRepairOnFailedMigration) {
+                repairAndRetryMigration(datasourceName, flyway);
+            } else {
+                throw new EdcPersistenceException("Flyway migration failed", e);
+            }
+        }
+    }
+
+    private void repairAndRetryMigration(String datasourceName, Flyway flyway) {
+        try {
+            var repairResult = flyway.repair();
+            handleFlywayRepairResult(datasourceName, repairResult);
+            var migrateResult = flyway.migrate();
+            handleFlywayMigrationResult(datasourceName, migrateResult);
+        } catch (FlywayException e) {
+            throw new EdcPersistenceException("Flyway migration failed", e);
+        }
+    }
+
+    private void handleFlywayRepairResult(String datasourceName, RepairResult repairResult) {
+        if (!repairResult.repairActions.isEmpty()) {
+            var repairActions = String.join(", ", repairResult.repairActions);
+            monitor.info(String.format(
+                    "Repair actions for datasource %s: %s",
+                    datasourceName,
+                    repairActions));
+        }
+
+        if (!repairResult.warnings.isEmpty()) {
+            var warnings = String.join(", ", repairResult.warnings);
+            throw new EdcPersistenceException(String.format(
+                    "Repairing datasource %s failed: %s",
+                    datasourceName,
+                    warnings));
+        }
+    }
+
+    private Flyway setupFlyway(
+            String datasourceName,
+            JdbcConnectionProperties jdbcConnectionProperties) {
         var dataSource = getDataSource(jdbcConnectionProperties);
         var migrationTableName = String.format("flyway_schema_history_%s", datasourceName);
         var migrationScriptLocation = String.join("/", MIGRATION_LOCATION_BASE, datasourceName);
-        final var flyway = Flyway.configure()
+        return Flyway.configure()
                 .baselineVersion(MigrationVersion.fromVersion("0.0.0"))
+                .baselineOnMigrate(true)
                 .failOnMissingLocations(true)
                 .dataSource(dataSource)
                 .table(migrationTableName)
                 .locations(migrationScriptLocation)
                 .load();
-        flyway.baseline();
-        var migrateResult = flyway.migrate();
-        handleFlywayResult(datasourceName, migrateResult);
     }
 
     private DataSource getDataSource(JdbcConnectionProperties jdbcConnectionProperties) {
@@ -58,27 +105,11 @@ public class FlywayService {
         return new ConnectionFactoryDataSource(connectionFactory);
     }
 
-    private void handleFlywayResult(String datasourceName, MigrateResult migrateResult) {
-        if (migrateResult.success) {
-            handleSuccessfulMigration(datasourceName, migrateResult);
-        } else {
-            handleFailedMigration(datasourceName, migrateResult);
-        }
-    }
-
-    private void handleFailedMigration(String datasourceName, MigrateResult migrateResult) {
-        var warnings = String.join(", ", migrateResult.warnings);
-        throw new EdcPersistenceException(String.format(
-                "Migration for datasource %s failed: %s",
-                datasourceName,
-                warnings));
-    }
-
-    private void handleSuccessfulMigration(String datasourceName, MigrateResult migrateResult) {
+    private void handleFlywayMigrationResult(String datasourceName, MigrateResult migrateResult) {
         if (migrateResult.migrationsExecuted > 0) {
             monitor.info(String.format(
-                    "Successfully migrated database for datasource %s from version %s to version " +
-                            "%s",
+                    "Successfully migrated database for datasource %s " +
+                            "from version %s to version %s",
                     datasourceName,
                     migrateResult.initialSchemaVersion,
                     migrateResult.targetSchemaVersion));
@@ -89,5 +120,6 @@ public class FlywayService {
                     migrateResult.initialSchemaVersion));
         }
     }
+
 
 }


### PR DESCRIPTION
# Pull Request

 Add possibility to flyway repair when migrations failed. Setting `edc.flyway.repair` controls, if the repair is executed when a migration fails.

## How Has This Been Tested?
- With uninitialized database
- With adapted migration scripts, which need to trigger repair
- With an up-to-date database state
