### PR TITLE
chore: set tagged version in docker-compose to latest release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - EDC_UI_DATA_MANAGEMENT_API_KEY=ApiKeyDefaultValue
       - EDC_UI_CATALOG_URLS=http://edc:11003/api/v1/ids/data
   edc:
-    image: ghcr.io/sovity/edc-mds:latest
+    image: ghcr.io/sovity/edc-mds:1.5.0
     depends_on:
       - postgresql
     environment:


### PR DESCRIPTION
Sets the used version to the last version (as desired).