### PR TITLE
refactor: add subsequent resource id filtering after sparql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Updated to EDC-Connector 0.0.1-milestone-8.
+- Added a subsequent resource-id filtering after sparql query, to filter out resources that do not belong to the connector.
 
 ## [1.5.0] - 2023-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Added a subsequent resource-id filtering after sparql query, to filter out resources that do not belong to the connector.
+
 ## [2.0.3] - 2023-03-24
 
 ### Fixed
@@ -38,7 +40,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Updated to EDC-Connector 0.0.1-milestone-8.
-- Added a subsequent resource-id filtering after sparql query, to filter out resources that do not belong to the connector.
 
 ## [1.5.1] - 2023-03-17
 

--- a/extensions/broker/src/main/java/de/sovity/extension/broker/service/IdsBrokerServiceImpl.java
+++ b/extensions/broker/src/main/java/de/sovity/extension/broker/service/IdsBrokerServiceImpl.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 public class IdsBrokerServiceImpl implements IdsBrokerService, EventSubscriber {
 
@@ -191,7 +192,10 @@ public class IdsBrokerServiceImpl implements IdsBrokerService, EventSubscriber {
                     String.class,
                     queryMessage,
                     () -> CONTEXT_BROKER_REGISTRATION);
-            return parseQueryResponse(resultMessageCompletableFuture.get());
+            var idList = parseQueryResponse(resultMessageCompletableFuture.get());
+            return idList.stream().filter(id -> id
+                    .startsWith(String.format("https://%s/", hostname.get())))
+                    .collect(Collectors.toList());
         } catch (MalformedURLException e) {
             throw new EdcException("Could not build brokerInfrastructureUrl", e);
         } catch (URISyntaxException e) {


### PR DESCRIPTION
Under certain circumstances the broker returns too many resources after execution of the SPARQL query, even those that do not belong to the connector itself given his hostname. These are filtered out herewith.

![image](https://user-images.githubusercontent.com/75306992/226389854-29672e64-dcad-4145-b643-49af9b29269a.png)
