### PR TITLE
fix empty EDC_VAULT file required error

### DIFF
--- a/.env
+++ b/.env
@@ -9,5 +9,5 @@ RELEASE_EDC_UI_IMAGE=ghcr.io/sovity/edc-ui:0.0.1-milestone-8-sovity2
 
 # For docker-compose-dev.yaml only:
 # Override images via ENV vars
-DEV_EDC_IMAGE=ghcr.io/sovity/edc-mds:latest
+DEV_EDC_IMAGE=ghcr.io/sovity/edc-ce-mds:latest
 DEV_EDC_UI_IMAGE=ghcr.io/sovity/edc-ui:latest

--- a/connector/.env
+++ b/connector/.env
@@ -90,3 +90,8 @@ POLICY_BROKER_BLACKLIST=REFERRING_CONNECTOR
 
 # Oauth default configurations
 EDC_OAUTH_PROVIDER_AUDIENCE=idsc:IDS_CONNECTORS_ALL
+
+# This file could contain an entry replacing the EDC_KEYSTORE ENV var
+# but for some reason it is required, and EDC won't start up if it isn't configured
+# it is created in the Dockerfile
+EDC_VAULT=/emtpy-properties-file.properties

--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -20,7 +20,8 @@ ARG JVM_ARGS=""
 # Install curl, then delete apt indexes to save image space
 RUN apt update \
     && apt install -y curl \
-    && rm -rf /var/cache/apt/archives /var/lib/apt/lists
+    && rm -rf /var/cache/apt/archives /var/lib/apt/lists \
+    && touch /emtpy-properties-file.properties
 
 WORKDIR /app
 

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -128,7 +128,7 @@ services:
       POSTGRESQL_PASSWORD: edc
       POSTGRESQL_DATABASE: edc
     volumes:
-      - 'postgresql:/bitnami/postgresql'
+      - 'postgresql2:/bitnami/postgresql'
 
 volumes:
   postgresql:


### PR DESCRIPTION
EDC_VAULT file is required, although its contents are optional.

The file is now added in Dockerfile, the property referring to it is added in the .env file, keeping the docker-composes clean.