### PR TITLE
fix: env release edc image

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ EDC_OAUTH_CLIENT_ID=override this via ENV vars
 
 # For docker-compose.yaml only:
 # Override images via ENV vars
-RELEASE_EDC_IMAGE=ghcr.io/sovity/edc-mds:3.0.0
+RELEASE_EDC_IMAGE=ghcr.io/sovity/edc-ce-mds:3.0.0
 RELEASE_EDC_UI_IMAGE=ghcr.io/sovity/edc-ui:0.0.1-milestone-8-sovity2
 
 # For docker-compose-dev.yaml only:


### PR DESCRIPTION
Switches 
`RELEASE_EDC_IMAGE=ghcr.io/sovity/edc-mds:3.0.0` (not working)
to
`RELEASE_EDC_IMAGE=ghcr.io/sovity/edc-ce-mds:3.0.0`