### PR TITLE
fix swagger annotations missing in api jars

### DIFF
--- a/extensions/wrapper/wrapper-broker-api/build.gradle.kts
+++ b/extensions/wrapper/wrapper-broker-api/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     compileOnly("org.projectlombok:lombok:1.18.26")
 
@@ -12,11 +11,11 @@ dependencies {
 
     api("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
     api("jakarta.validation:jakarta.validation-api:3.0.2")
+    api("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
+    api("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
+    api("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
     implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
-    implementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
 }
 
 val sovityEdcGroup: String by project

--- a/extensions/wrapper/wrapper-common-api/build.gradle.kts
+++ b/extensions/wrapper/wrapper-common-api/build.gradle.kts
@@ -4,17 +4,16 @@ plugins {
 }
 
 dependencies {
-
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     compileOnly("org.projectlombok:lombok:1.18.26")
 
     api("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
     api("jakarta.validation:jakarta.validation-api:3.0.2")
+    api("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
+    api("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
+    api("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
     implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
-    implementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
 }
 
 val sovityEdcGroup: String by project

--- a/extensions/wrapper/wrapper-ee-api/build.gradle.kts
+++ b/extensions/wrapper/wrapper-ee-api/build.gradle.kts
@@ -4,17 +4,16 @@ plugins {
 }
 
 dependencies {
-
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     compileOnly("org.projectlombok:lombok:1.18.26")
 
     api("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
     api("jakarta.validation:jakarta.validation-api:3.0.2")
+    api("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
+    api("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
+    api("jakarta.servlet:jakarta.servlet-api:5.0.0")
 
     implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.9")
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.9")
-    implementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
 }
 
 val sovityEdcGroup: String by project


### PR DESCRIPTION
it was causing WARNINGS when importing those JARs, as you had the code, but not the libraries for the annotations