### PR TITLE
docs: remove EDC_CLEARINGHOUSE_LOG_URL from production deployment-guide

### DIFF
--- a/docs/deployment-guide/goals/production/README.md
+++ b/docs/deployment-guide/goals/production/README.md
@@ -124,9 +124,6 @@ EDC_API_AUTH_KEY: ApiKeyDefaultValue
 MY_EDC_MAINTAINER_URL: "https://sovity.de"
 MY_EDC_MAINTAINER_NAME: "sovity GmbH"
 
-# (MDS Only) Clearing House
-EDC_CLEARINGHOUSE_LOG_URL: 'https://clearing.test.mobility-dataspace.eu/messages/log'
-
 # DAPS URL
 EDC_OAUTH_TOKEN_URL: 'https://daps.test.mobility-dataspace.eu/token'
 EDC_OAUTH_PROVIDER_JWKS_URL: 'https://daps.test.mobility-dataspace.eu/jwks.json'


### PR DESCRIPTION
Closes #636 

Since the migration from MS8 to EDC v0.x.y, there is no longer a Clearing-House connection with the current sovity EDC CE (currently v6.0.0). The setting can be removed from the documentation.